### PR TITLE
audiosystem-passthrough: Move dummy-af service to system session.

### DIFF
--- a/rpm/audiosystem-passthrough-dummy-af.service
+++ b/rpm/audiosystem-passthrough-dummy-af.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Binder AudioFlinger dummy service
-After=pre-user-session.target
+DefaultDependencies=no
+After=local-fs.target
+Before=droid-hal-init.service
 
 [Service]
 Environment=AUDIOSYSTEM_PASSTHROUGH_TYPE=af
@@ -9,4 +11,4 @@ ExecStart=/usr/libexec/audiosystem-passthrough/audiosystem-passthrough --address
 Restart=always
 
 [Install]
-WantedBy=user-session.target
+WantedBy=multi-user.target

--- a/rpm/audiosystem-passthrough.spec
+++ b/rpm/audiosystem-passthrough.spec
@@ -50,10 +50,11 @@ Binder android.hardware.audio@2.0 dummy service.
 %install
 rm -rf %{buildroot}
 make DESTDIR=%{buildroot} PREFIX=%{_prefix} LIBDIR=%{_libdir} install
-install -D -m 644 %{SOURCE1} %{buildroot}%{_userunitdir}/audiosystem-passthrough-dummy-af.service
+install -D -m 644 %{SOURCE1} %{buildroot}%{_unitdir}/audiosystem-passthrough-dummy-af.service
 install -D -m 644 %{SOURCE2} %{buildroot}%{_userunitdir}/audiosystem-passthrough-dummy-hw2_0.service
+install -d -m 755 %{buildroot}%{_unitdir}/multi-user.target.wants
 install -d -m 755 %{buildroot}%{_userunitdir}/user-session.target.wants
-ln -s ../audiosystem-passthrough-dummy-af.service %{buildroot}%{_userunitdir}/user-session.target.wants/audiosystem-passthrough-dummy-af.service
+ln -s ../audiosystem-passthrough-dummy-af.service %{buildroot}%{_unitdir}/multi-user.target.wants/audiosystem-passthrough-dummy-af.service
 ln -s ../audiosystem-passthrough-dummy-hw2_0.service %{buildroot}%{_userunitdir}/user-session.target.wants/audiosystem-passthrough-dummy-hw2_0.service
 
 %post
@@ -74,8 +75,8 @@ ln -s ../audiosystem-passthrough-dummy-hw2_0.service %{buildroot}%{_userunitdir}
 
 %files dummy-af
 %defattr(-,root,root,-)
-%{_userunitdir}/audiosystem-passthrough-dummy-af.service
-%{_userunitdir}/user-session.target.wants/audiosystem-passthrough-dummy-af.service
+%{_unitdir}/audiosystem-passthrough-dummy-af.service
+%{_unitdir}/multi-user.target.wants/audiosystem-passthrough-dummy-af.service
 
 %files dummy-hw2_0
 %defattr(-,root,root,-)


### PR DESCRIPTION
[audiosystem-passthrough] Move dummy-af service to system session. JB#50794

Devices which need audio_policy running in droidmedia require audio_flinger
to be present when minimediaservice is starting.