### PR TITLE
hw2_0: Move dummy-hw2_0 to system session. Fixes JB#56322

### DIFF
--- a/rpm/audiosystem-passthrough-dummy-hw2_0.service
+++ b/rpm/audiosystem-passthrough-dummy-hw2_0.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Binder android.hardware.audio@2.0 dummy service
-After=pre-user-session.target
+After=droid-hal-init.service
+Before=ofono.service
+Conflicts=bluebinder.service
 
 [Service]
 Environment=AUDIOSYSTEM_PASSTHROUGH_TYPE=hw2_0
@@ -9,4 +11,4 @@ ExecStart=/usr/libexec/audiosystem-passthrough/audiosystem-passthrough --address
 Restart=always
 
 [Install]
-WantedBy=user-session.target
+WantedBy=multi-user.target

--- a/rpm/audiosystem-passthrough.spec
+++ b/rpm/audiosystem-passthrough.spec
@@ -51,11 +51,10 @@ Binder android.hardware.audio@2.0 dummy service.
 rm -rf %{buildroot}
 make DESTDIR=%{buildroot} PREFIX=%{_prefix} LIBDIR=%{_libdir} install
 install -D -m 644 %{SOURCE1} %{buildroot}%{_unitdir}/audiosystem-passthrough-dummy-af.service
-install -D -m 644 %{SOURCE2} %{buildroot}%{_userunitdir}/audiosystem-passthrough-dummy-hw2_0.service
+install -D -m 644 %{SOURCE2} %{buildroot}%{_unitdir}/audiosystem-passthrough-dummy-hw2_0.service
 install -d -m 755 %{buildroot}%{_unitdir}/multi-user.target.wants
-install -d -m 755 %{buildroot}%{_userunitdir}/user-session.target.wants
 ln -s ../audiosystem-passthrough-dummy-af.service %{buildroot}%{_unitdir}/multi-user.target.wants/audiosystem-passthrough-dummy-af.service
-ln -s ../audiosystem-passthrough-dummy-hw2_0.service %{buildroot}%{_userunitdir}/user-session.target.wants/audiosystem-passthrough-dummy-hw2_0.service
+ln -s ../audiosystem-passthrough-dummy-hw2_0.service %{buildroot}%{_unitdir}/multi-user.target.wants/audiosystem-passthrough-dummy-hw2_0.service
 
 %post
 
@@ -80,5 +79,5 @@ ln -s ../audiosystem-passthrough-dummy-hw2_0.service %{buildroot}%{_userunitdir}
 
 %files dummy-hw2_0
 %defattr(-,root,root,-)
-%{_userunitdir}/audiosystem-passthrough-dummy-hw2_0.service
-%{_userunitdir}/user-session.target.wants/audiosystem-passthrough-dummy-hw2_0.service
+%{_unitdir}/audiosystem-passthrough-dummy-hw2_0.service
+%{_unitdir}/multi-user.wants/audiosystem-passthrough-dummy-hw2_0.service


### PR DESCRIPTION
[hw2_0] Some of the MTK-based devices (with audio@2.0 interface version)
require dummy-hw2_0 being launched to complete initialization of the
rilproxy. In some usecases it might cause troubles such as 'dead' ofono
after Startup Wizard procedure.
Fixes JB#56322.