### PR TITLE
hw2_0: Omit 'Conflicts=bluebinder.service' declaration. Contributes t…

### DIFF
--- a/rpm/audiosystem-passthrough-dummy-hw2_0.service
+++ b/rpm/audiosystem-passthrough-dummy-hw2_0.service
@@ -2,7 +2,6 @@
 Description=Binder android.hardware.audio@2.0 dummy service
 After=droid-hal-init.service
 Before=ofono.service
-Conflicts=bluebinder.service
 
 [Service]
 Environment=AUDIOSYSTEM_PASSTHROUGH_TYPE=hw2_0


### PR DESCRIPTION
…o JB#56322.

Get rid of 'Conflicts=bluebinder.service' declaration in
audiosystem-passtgrough-dummy-hw2_0.service becaus it breaks Bluetooth
support on several devices by blocking start of the bluebinder.service.

[hw2_0] Omit 'Conflicts=bluebinder.service' declaration. Contributes to
JB#56322.